### PR TITLE
Fix url in config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: "Cycle.js"
 author: "Andre Staltz"
 description: "A fully reactive JavaScript framework for Human-Computer Interaction"
 more: "read more"
-url: "http://cyclejs.github.io"
+url: "http://cycle.js.org/"
 permalink: none
 
 excerpt_separator: "\n\n\n"


### PR DESCRIPTION
replaces `"http://cyclejs.github.io"` to `"http://cycle.js.org/"`

The effect of this change is that it fixes canonical link.

``` html
    <title>Cycle.js</title>
    <link rel="canonical" href="http://cyclejs.github.io/index.html">
    <link href="/main.css" rel="stylesheet" type="text/css">
```
