### PR TITLE
use templated string in example

### DIFF
--- a/_posts/2015-01-31-getting-started.md
+++ b/_posts/2015-01-31-getting-started.md
@@ -60,7 +60,7 @@ function main() {
   return {
     DOM: Rx.Observable.interval(1000)
       .map(i => CycleDOM.h(
-        'h1', '' + i + ' seconds elapsed'
+        'h1', `${i} seconds elapsed`
       ))
   };
 }


### PR DESCRIPTION
I always stumble over this. I think this is more aligned with the explaining paragraph below and a general good practise to indicate that this is a string and not a number which casts to a string.
