### PR TITLE
Wrong hJSX link

### DIFF
--- a/_posts/2015-01-22-documentation.md
+++ b/_posts/2015-01-22-documentation.md
@@ -104,7 +104,7 @@ elements with `div('.wrapper', [ h1('Header') ])` instead of
 
 An adapter around virtual-hyperscript `h()` to allow JSX to be used easily
 with Babel. Place the [Babel configuration comment](
-http://babeljs.io/docs/advanced/transformers/other/react/) `@jsx hJSX` at
+http://babeljs.io/docs/plugins/transform-react-jsx/) `@jsx hJSX` at
 the top of the ES6 file, make sure you import `hJSX` with
 `import {hJSX} from '@cycle/dom'`, and then you can use JSX to create
 VTrees.


### PR DESCRIPTION
In the hJSX section the "Babel configuration comment" link is pointing to a 404 babel page.
