### PR TITLE
Fixes mixed content error for jsbin script

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -28,7 +28,7 @@
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,200italic,300italic,400italic,600italic,700italic' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Merriweather:400,700' rel='stylesheet' type='text/css'>
     <link href='//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
-    <script async src="http://static.jsbin.com/js/embed.js"></script>
+    <script async src="//static.jsbin.com/js/embed.js"></script>
   </head>
   <body>
 {{ content }}


### PR DESCRIPTION
Error in Chrome console:
```
Mixed Content: The page at 'https://cycle.js.org/' was loaded over HTTPS, but requested an insecure script 'http://static.jsbin.com/js/embed.js'. This request has been blocked; the content must be served over HTTPS.
```