### PR TITLE
Fix md syntax in 2015-01-25-components.md 

### DIFF
--- a/_posts/2015-01-25-components.md
+++ b/_posts/2015-01-25-components.md
@@ -603,14 +603,14 @@ The takeaway is: **when creating multiple instances of the same type of componen
 >
 > Instead of exporting the original non-isolated component, like this:
 >
-> `export function OriginalComponent(sources)`<br />
+> `export function OriginalComponent(sources) {`<br />
 > `  // ...`<br />
 > `}`<br />
 >
 > just export a function that calls `isolate()`:
 >
 > `export function Component(sources) {`<br />
-> `  return isolate(OriginalComponent)(sources);`<br />
+> `  return isolate(OriginalComponent)(sources);`<br />
 > `}`<br />
 >
 > Doing this gives the consumer automatic isolation without having to think about it.


### PR DESCRIPTION
Looked like this before on desktop Chrome and Safari.

<img width="646" alt="screen shot 2017-01-13 at 4 30 01 pm" src="https://cloud.githubusercontent.com/assets/802586/21946324/e47e8494-d9ad-11e6-9612-8afc814c5f2f.png">
